### PR TITLE
Add the shebang line to removal_script_linux.sh

### DIFF
--- a/linux_scripts/removal_script_linux.sh
+++ b/linux_scripts/removal_script_linux.sh
@@ -1,1 +1,2 @@
+#!/bin/bash
 sudo uninstall-hs --thru 8.2.1 --remove


### PR DESCRIPTION
Otherwise you'll get the error message

```
Failed to execute process './removal_script_linux.sh'. Reason:
exec: Exec format error
The file './removal_script_linux.sh' is marked as an executable but could not be run by the operating system.
```